### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/src/ad-service/Pages/Shared/UserAuthService.cs
+++ b/src/ad-service/Pages/Shared/UserAuthService.cs
@@ -43,7 +43,8 @@ namespace AdService.Pages.Shared
                 "http://"
                 + Environment.GetEnvironmentVariable("USER_AUTH_SERVICE_ADDRESS")
                 + "/auth/isValid");
-            var payload = "{\"jwt\":\"" + jwt + "\"}";
+            var sanitizedJwt = WebUtility.HtmlEncode(jwt);
+            var payload = "{\"jwt\":\"" + sanitizedJwt + "\"}";
             var content = new StringContent(payload, Encoding.UTF8, "application/json");
 
             HttpResponseMessage userAuthServiceResponse;

--- a/src/proxy-service/build.gradle
+++ b/src/proxy-service/build.gradle
@@ -14,6 +14,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.apache.commons:commons-text:1.12.0'
 	// https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore
 	// WARNING this is a version of httpcore that is vulnerable to CLRF injection in HTTP headers
 	implementation group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.5'

--- a/src/proxy-service/src/main/java/org/dynatrace/ssrfservice/ProxyController.java
+++ b/src/proxy-service/src/main/java/org/dynatrace/ssrfservice/ProxyController.java
@@ -22,6 +22,7 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -89,8 +90,9 @@ public class ProxyController {
             execute = httpclient.execute(httpget, httpContext);
             InputStream content = execute.getEntity().getContent();
             String s = IOUtils.toString(content, Charset.defaultCharset());
+            String escapedContent = org.apache.commons.text.StringEscapeUtils.escapeHtml4(s);
             execute.close();
-            return s;
+            return escapedContent;
         } catch (Exception e) {
             finishCurrentSpanWithError(httpContext, e);
 


### PR DESCRIPTION
Potential fixes for 2 code scanning alerts from the [Cross-site scripting (CWE-79) 2](https://github.com/orgs/GeekMasherOrg/security/campaigns/6) security campaign:
- https://github.com/GeekMasherOrg/unguard/security/code-scanning/31
To fix the problem, we need to ensure that the response content is properly sanitized or encoded before being returned to the client. One way to achieve this is by using a library that provides HTML escaping functionality to prevent XSS attacks. The `org.apache.commons.text.StringEscapeUtils` library can be used for this purpose.

  We will modify the code to escape the response content before returning it. Specifically, we will use the `StringEscapeUtils.escapeHtml4` method to encode the response content.
  


- https://github.com/GeekMasherOrg/unguard/security/code-scanning/10
To fix the problem, we need to sanitize the `jwt` value before using it to construct the JSON payload. We can use the `WebUtility.HtmlEncode` method from the `System.Net` namespace to encode the `jwt` value, ensuring that any potentially malicious content is neutralized.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
